### PR TITLE
New Component for We Are Sunrise Section Text

### DIFF
--- a/app/components/WeAreSunriseSection/WeAreSunriseSection.tsx
+++ b/app/components/WeAreSunriseSection/WeAreSunriseSection.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import { ArrowButton, H2, P } from "components";
+import { ArrowButton, H2, P, WeAreSunriseSectionText } from "components";
 
 import styles from "./weAreSunriseSection.module.scss";
 
@@ -15,17 +15,17 @@ export const WeAreSunriseSection = () => {
 			</div>
 			<div className="flex">
 				<div className={styles.textWrapper}>
-					<P>
+					<WeAreSunriseSectionText>
 						Our team of experienced designers and marketing professionals work
 						closely with each client to understand their unique vision and
 						develop tailored solutions that align with their goals.
-					</P>
-					<P>
+					</WeAreSunriseSectionText>
+					<WeAreSunriseSectionText>
 						From designing eye-catching logos and brand identities, to building
 						custom websites that engage and convert visitors, to crafting
 						effective influencer marketing campaigns, we are dedicated to
 						helping our clients succeed in the digital space.
-					</P>
+					</WeAreSunriseSectionText>
 					<ArrowButton className="bg-primary mt-3.5" width="10px" height="10px">
 						Learn more
 					</ArrowButton>

--- a/app/components/WeAreSunriseSectionText/WeAreSunRiseSectionText.module.scss
+++ b/app/components/WeAreSunriseSectionText/WeAreSunRiseSectionText.module.scss
@@ -1,0 +1,4 @@
+.component{
+  font-size: 24px;
+  font-weight: 400;
+}

--- a/app/components/WeAreSunriseSectionText/WeAreSunriseSectionText.tsx
+++ b/app/components/WeAreSunriseSectionText/WeAreSunriseSectionText.tsx
@@ -1,0 +1,29 @@
+import classNames from "classnames";
+import { FunctionComponent, ReactNode } from "react";
+
+import styles from "./WeAreSunriseSectionText.module.scss";
+
+type TProps = {
+	children: string | ReactNode;
+	isText?: boolean;
+	className?: string;
+};
+
+export const WeAreSunriseSectionText: FunctionComponent<TProps> = ({
+	children,
+	isText,
+	className: propsClassName,
+	...props
+}) => {
+	const componentClassName = classNames(styles.component, propsClassName);
+
+	return isText ? (
+		<span className={componentClassName} {...props}>
+			{children}
+		</span>
+	) : (
+		<p className={componentClassName} {...props}>
+			{children}
+		</p>
+	);
+};

--- a/app/components/WeAreSunriseSectionText/index.ts
+++ b/app/components/WeAreSunriseSectionText/index.ts
@@ -1,0 +1,1 @@
+export * from "./WeAreSunriseSectionText";

--- a/app/components/index.ts
+++ b/app/components/index.ts
@@ -14,6 +14,7 @@ export * from "./WhatWeDoCard";
 export * from "./OurProjectsSection";
 export * from "./ImagesWrapper";
 export * from "./WhoWeWorkWithSection";
+export * from "./WeAreSunriseSectionText"
 export * from "./WhoWeWorkWithCard";
 export * from "./ContactUsSection";
 export * from "./Input";


### PR DESCRIPTION
Replace usage of P component with WeAreSunriseSectionText component.

This way, specially applied font styles can be applied to the text. This is a different section of the page, warranting its own styling, separate from other standard text fields. 

Image attached with the way this looks now. 

<img width="1334" alt="Screenshot 2024-04-06 at 21 52 45" src="https://github.com/dealwith/sunrise-studio-website/assets/41486217/0fa91bfa-993f-4665-97fa-82bad4059b14">
