### PR TITLE
Fix Page Footer

### DIFF
--- a/app/components/Footer/Footer.tsx
+++ b/app/components/Footer/Footer.tsx
@@ -6,10 +6,10 @@ import styles from "./footer.module.scss";
 
 export const Footer = () => {
   return (
-    <footer className={styles.component}>
+    <footer className="mt-44 bg-secondary w-screen absolute left-0">
       <div className={styles.contentWrapper}>
         <FooterNavigation />
-        <div className={styles.content}>
+        <div className="w-2/3 flex-col flex gap-8">
           <H4 className={styles.text}>
             Write us to schedule a call to discuss your project and learn more
             about sunrise studio

--- a/app/components/Footer/footer.module.scss
+++ b/app/components/Footer/footer.module.scss
@@ -5,7 +5,7 @@
   background-color: var(--red);
   width: 100vw;
   position: absolute;
-  left:0;
+  left: 0;
 }
 
 .contentWrapper {

--- a/app/components/Footer/footer.module.scss
+++ b/app/components/Footer/footer.module.scss
@@ -4,6 +4,8 @@
   margin-top: 174px;
   background-color: var(--red);
   width: 100vw;
+  position: absolute;
+  left:0;
 }
 
 .contentWrapper {

--- a/app/components/Footer/footer.module.scss
+++ b/app/components/Footer/footer.module.scss
@@ -1,26 +1,11 @@
 @use "styles/mixin";
 
-.component {
-  margin-top: 174px;
-  background-color: var(--red);
-  width: 100vw;
-  position: absolute;
-  left: 0;
-}
-
 .contentWrapper {
   padding: 60px 80px;
   margin: 0 auto;
   @include mixin.maxWidth(1300px);
   display: flex;
   justify-content: space-between;
-}
-
-.content {
-  width: 66%;
-  display: flex;
-  flex-direction: column;
-  gap: 32px;
 }
 
 .text {

--- a/app/layout.module.scss
+++ b/app/layout.module.scss
@@ -1,5 +1,5 @@
 .component {
   width: 100%;
   background-color: var(--bgGray);
-  overflow-x:hidden;
+  overflow-x: hidden;
 }

--- a/app/layout.module.scss
+++ b/app/layout.module.scss
@@ -1,4 +1,5 @@
 .component {
   width: 100%;
   background-color: var(--bgGray);
+  overflow-x:hidden;
 }


### PR DESCRIPTION
- Fix that darn footer to take up the whole page. Currently, the footer is uneven and doesn't utilize the bottom of the page correctly. 

- In addition, add X-overflow on page to be hidden so overflowing elements don't cause the scrollbar to appear.

Current Implementation: 
<img width="1654" alt="Screenshot 2024-05-12 at 17 43 06" src="https://github.com/dealwith/sunrise-studio-website/assets/41486217/7c245a0f-966f-447d-8ec2-800f52cd9e91">

